### PR TITLE
[WIP]メールでの会員登録画面へのリンク,会員登録画面のフッター,画像の修正

### DIFF
--- a/app/views/registration/_registration_footer.html.haml
+++ b/app/views/registration/_registration_footer.html.haml
@@ -1,0 +1,14 @@
+%footer.single-footer
+  %nav
+    %ul.clearfix
+      %li
+        = link_to "プライバシーポリシー", "#"
+      %li
+        = link_to "メルカリ利用規約", "#"
+      %li
+        = link_to "特定商取引に関する表記", "#"
+  = link_to "#", class: "single-footer__logo" do
+    =image_tag("logo_gray.svg")
+  %p
+    %small 
+      © Mercari, Inc.

--- a/app/views/registration/index_step0.html.haml
+++ b/app/views/registration/index_step0.html.haml
@@ -2,14 +2,14 @@
   %header.single-header
     %h1.single-header__logo--center
       = link_to "#" do
-        = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1714804574", alt: "mercari"
+        =image_tag("fmarket_logo_red.svg")
   %main.single-main
     %section.single-main__container
       %h2.single-main__container__title
         新規会員登録
       .step0
         .step0__contents
-          =link_to "#", class: "btn-def--mail" do
+          =link_to new_user_registration_path, class: "btn-def--mail" do
             %i.far.fa-envelope
             %span<>
             メールアドレスで登録する
@@ -21,17 +21,4 @@
             %i.fab.fa-google
             %span<>
             Googleで登録する                           
-  %footer.single-footer
-    %nav
-      %ul.clearfix
-        %li
-          = link_to "プライバシーポリシー", "#"
-        %li
-          = link_to "メルカリ利用規約", "#"
-        %li
-          = link_to "特定商取引に関する表記", "#"
-    = link_to "#", class: "single-footer__logo" do
-      = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?1714804574"
-    %p
-      %small 
-        © Mercari, Inc.
+  = render "registration_footer"

--- a/app/views/registration/index_step1.html.haml
+++ b/app/views/registration/index_step1.html.haml
@@ -2,7 +2,7 @@
   %header.single-header
     %h1.single-header__logo
       = link_to "#" do
-        = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1714804574", alt: "mercari"
+        =image_tag("fmarket_logo_red.svg")
     %nav.single-header__progress
       %ol
         %li.single-header__progress__text--active{ id: "first" }
@@ -103,17 +103,4 @@
                 and
                 = link_to "Terms of Service", "#" , target:"_blank"
                 apply.
-  %footer.single-footer
-    %nav
-      %ul.clearfix
-        %li
-          = link_to "プライバシーポリシー", "#"
-        %li
-          = link_to "メルカリ利用規約", "#"
-        %li
-          = link_to "特定商取引に関する表記", "#"
-    = link_to "#", class: "single-footer__logo" do
-      = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?1714804574"
-    %p
-      %small 
-        © Mercari, Inc.
+  = render "registration_footer"


### PR DESCRIPTION
## WHAT
■会員登録画面の0ページ目（メールかFacebookかGoogleを選択する部分）の修正
・「メールで会員登録する」ボタンのリンク
・会員登録画面のフッターを部分テンプレート化
・画像の修正（メルカリから模倣サイトのロゴへ変更）
https://gyazo.com/434d16431ead3401681ffc372b71e0ce

## WHY
・アプリ制作のため