### PR TITLE
出品ページのプレビュー表示の実装修正

### DIFF
--- a/app/assets/javascripts/previews.js
+++ b/app/assets/javascripts/previews.js
@@ -1,56 +1,55 @@
-$(function () {
-  const buildFileField = (index)=> {
-    const html = `<div data-index="${index}" class="js-file_group">
-                    <input class="js-file" type="file"
-                    name="product[images_attributes][${index}][product_image]"
-                    id="product_images_attributes_${index}_product_image"><br>
-                    <div class="js-remove"></div>
-                  </div>`;
-    return html;
-  }
+$(() => {
+  let images = [];
+  const previewHTML = img => {
+    const html =
+      `<div class="preview">
+        <div class="preview__img">
+          <img src="${img}">
+        </div>
+        <div class="preview__delete">
+          <div class="preview__delete--button">
+            <p>削除</p>
+          </div>
+        </div>
+      </div>`;
+    $(".dropbox").prepend(html);
+  };
 
-  const buildImg = (index, url)=> {
-    const html = `<img data-index="${index}" src="${url}" width="100px" height="100px">`;
-    return html;
-  }
-  let fileIndex = [1,2,3,4,5,6,7,8,9,10];
-  // 既に使われているindexを除外
-  lastIndex = $('.js-file_group:last').data('index');
-  fileIndex.splice(0, lastIndex);
-  $('.hidden-destroy').hide();
-  
-  $('#image-box').on('change', '.js-file', function(e) {
-    const targetIndex = $(this).parent().data('index');
-    // ファイルのブラウザ上でのURLを取得する
-    const file = e.target.files[0];
-    const blobUrl = window.URL.createObjectURL(file);
-    
-    // 該当indexを持つimgがあれば取得して変数imgに入れる(画像変更の処理)
-    if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
-      img.setAttribute('src', blobUrl);
-    } else {  // 新規画像追加の処理
-      $('#previews').append(buildImg(targetIndex, blobUrl));
-      // fileIndexの先頭の数字を使ってinputを作る
-      $('#image-box').append(buildFileField(fileIndex[0]));
-      fileIndex.shift();
-      // 末尾の数に1足した数を追加する
-      fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
+  $(".dropbox__img").on("drop", e => {
+    e.preventDefault();
+    e.stopPropagation();
+    let dropImg = e.originalEvent.dataTransfer.files;
+    let previewCount = $(".preview").length;
+    let fileImput = $("#sell-img")[0];
+    if (dropImg.length == 1) {
+      if (previewCount <= 9) {
+        let img = URL.createObjectURL(dropImg[0]);
+        previewHTML(img);
+        images.push(dropImg[0].name);
+        fileImput.files = dropImg;
+        if (previewCount == 9) {
+          $(".dropbox__img").remove();
+        }
+      }
+    } else {
+      alert("1枚づつ入れてね！");
     }
-
-  });
-  
-  $('#image-box').on('click', '.js-remove', function() {
-    const targetIndex = $(this).parent().data('index');
-    // 該当indexを振られているチェックボックスを取得する
-    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
-    // もしチェックボックスが存在すればチェックを入れる
-    if (hiddenCheck) hiddenCheck.prop('checked', true);
-
-    $(this).parent().remove();
-    $(`img[data-index="${targetIndex}"]`).remove();
-
-    // 画像入力欄が0個にならないようにしておく
-    if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
   });
 
-})
+  $(document).on("click", ".preview__delete--button", function () {
+    $(this).closest(".preview").remove();
+  });
+
+  $(document).on("drop", e => {
+    e.stopPropagation();
+    e.preventDefault();
+  });
+  $(document).on("dragenter", e => {
+    e.stopPropagation();
+    e.preventDefault();
+  });
+  $(document).on("dragover", e => {
+    e.stopPropagation();
+    e.preventDefault();
+  });
+});

--- a/app/assets/stylesheets/_new.scss
+++ b/app/assets/stylesheets/_new.scss
@@ -65,85 +65,73 @@
             margin:8px 0 0;
           }
 
-          .preview-area{
-            margin:16px auto 0;
-            
-            .product-image-list{
-              display:flex;
-              flex-wrap:wrap;
-              width: 615px;
-
-              .product-uploaded{
-                width:114px;
-                height:162px;
-                margin:0 6px 6px 0;
-                background:#f5f5f5;
-                text-align:center;
-              
-                &__img {
-                  width:114px;
-                  height:114px;
-                  object-fit: contain;
+          .dropbox {
+            &__img {
+              display: block;
+              text-align: center;
+              border: 1px dashed lightgray;
+              min-width: 115px;
+              height: 160px;
+              background: #f5f5f5;
+              margin-top: 5px;
+              p {
+                font-size: 13px;
+                margin-top: 55px;
+              }
+              input[type="file"] {
+                display: none;
+              }
+            }
+          }
+          .preview {
+            margin: 0 2px 10px 2px;
+            width: 120px;
+            height: auto;
+            padding: 1rem 0 0;
+            box-sizing: border-box;
+            display: inline-block;
+            border: 1px solid lightgray;
+            background: #f5f5f5;
+            &__img {
+              width: 100%;
+              height: 78px;
+              img {
+                width: 100%;
+                max-height: 70px;
+                object-fit: cover;
+                border-top: rgb(160, 160, 160) solid 1px;
+                border-bottom: rgb(160, 160, 160) solid 1px;
+              }
+            }
+            &__delete {
+              display: flex;
+              justify-content: space-around;
+              padding-bottom: 5px;
+              &--button {
+                cursor: pointer;
+                text-align: center;
+                width: 45%;
+                line-height: 32px;
+                height: 30px;
+                margin-bottom: 1px;
+                background-color: #0099e8;
+                border-radius: 5px;
+                &:hover {
+                  opacity: 0.6;
                 }
-              
-                &__delete {
-                  text-decoration: none;
-                  color: dodgerblue;
-                  font-size: 20px;
-                  padding: 3px;
-                  border: 2px solid dodgerblue;
-                  border-radius: 4px;
-                  cursor: pointer;
-
-                  &:hover{
-                    opacity: 0.7;
+                p {
+                  display: inline-block;
+                  color: #fff;
+                  &:hover {
+                    text-decoration: none;
                   }
                 }
               }
             }
-
-            .upload-area{
-              border:1px dashed #ccc;
-              margin:0 6px 6px 0;
-              cursor: pointer;
-              width:100%;
-              height:162px;
-              background:#f5f5f5;
-              position:relative;
-
-              &__dropbox{
-                height:162px;
-
-                input {
-                  position: absolute;
-                  display:block;
-                  width:100%;
-                  height:100%;
-                  opacity: 0;
-                  top: 0;
-                  right: 0;
-                  z-index: 10;
-                }
-
-                p {
-                  word-wrap:break-word;
-                  text-align:center;
-                  position: absolute;
-                  top: 60px;
-                  left: 5%;
-                  right: 5%;
-                }
-              }
-            } 
           }
-          .preview-reset{
-            margin-top:15px;
-            font-size:12px;
-            cursor: pointer;
-            border: 2px solid #888;
-            border-radius: 2px;
+
             
-          }
+          
         }
         // 商品名
         .sell--content {

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -11,22 +11,11 @@
             %span.form--caution 
               必須
           %p.img__upload__comment 最大10枚までアップロードできます
-          .preview-area
-            %ul.product-image-list#product-image-list
-              .upload-area
-                .upload-area__dropbox
-                  %p 
-                    ドラッグアンドドロップ
-                    %br
-                    またはクリックしてファイルをアップロード
-                  #image-box
-                    #previews
-                      - if @product.persisted?
-                        - @product.images.each_with_index do |image, i|
-                          = image_tag image.src.url, data: {index: i}, width: "100", height: "100"
-                      = f.fields_for :images do |image|
-                        .js-file_group{data: {index:image.index}}
-                        = image.file_field :product_image,class:"js-file"
+          .dropbox
+            %label.dropbox__img
+              %p ドラッグアンドドロップ<br>またはクリックしてファイルをアップロード
+              = f.fields_for :images do |image|
+                = image.file_field :product_image, id: "sell-img"
         .sell--content
           .sell--content__name
             %h3.sell--content__name__name


### PR DESCRIPTION
# What 
商品出品ページプレビュー表示を１０枚まで二段表示とし、プレビュー画像を削除可能とする実装を行った。
ドラッグ&ドロップにて画像プレビュー表示されるように実装した

# Why
プレビュー画像を見やすくし、今後の実装につなげるため

ドラッグ&ドロップビュー
https://gyazo.com/5a8a9d5719bc90e1722210cf780bba56
二段表示&削除ビュー
https://gyazo.com/be2e7b953a18504a5a1ae52da9039294

