### PR TITLE
商品情報編集画面プレビュー表示の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -36,8 +36,7 @@ class ProductsController < ApplicationController
     @comments =@product.comments
   end
   def update
-    product=Product.includes(:comments).find(params[:id])
-    if product.update(product_params)
+    if @product.update(update_params)
       redirect_to product_path
     else
       render :edit
@@ -60,6 +59,9 @@ class ProductsController < ApplicationController
 
     def set_product
       @product = Product.includes(:comments).find(params[:id])
+    end
+    def update_params
+      params.require(:product).permit(:name, :explain, :price, :size, :brand_id, :category_id, :status, :shipping_date, :category_id, :brand_id, :user_id, images_attributes: [:product_image, :id])
     end
     
 end

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -15,12 +15,12 @@
           .sell__main__content__file__up__head__preview
             %ul#preview_list
               - i = 0
-              - @product.images[0..4].each do |image|
+              - @product.images.each_with_index do |image,i|
                 %li.upload-sell-item{id: i}
                   - i += 1
                   .preview
                     .preview__img
-                      %img{src: image.product_image, size: "114x114"}/
+                      =image_tag(@product.images[0].product_image.url,size: "114x114")
                     .preview__delete
                       .preview__delete--button
                         %p 削除

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -12,17 +12,23 @@
             %span.form--caution 
               必須
           %p.img__upload__comment 最大10枚までアップロードできます
-          .preview-area
-            %ul.product-image-list#product-image-list
-              .upload-area
-                .upload-area__dropbox
-                  %p 
-                    ドラッグアンドドロップ
-                    %br
-                    またはクリックしてファイルをアップロード
-                    = f.fields_for :images do |image|
-                      .js-file_group{data: {index:image.index}}
-                      = image.file_field :product_image,class:"js-file"
+          .sell__main__content__file__up__head__preview
+            %ul#preview_list
+              - i = 0
+              - @product.images[0..4].each do |image|
+                %li.upload-sell-item{id: i}
+                  - i += 1
+                  .preview
+                    .preview__img
+                      %img{src: image.product_image, size: "114x114"}/
+                    .preview__delete
+                      .preview__delete--button
+                        %p 削除
+              .dropbox
+                %label.dropbox__img
+                  %p ドラッグアンドドロップ<br>またはクリックしてファイルをアップロード
+                  = f.fields_for :images do |i|
+                    = i.file_field :product_image,id:"sell-img"
         .sell--content
           .sell--content__name
             %h3.sell--content__name__name


### PR DESCRIPTION
# What
gem:変更なし
DB:変更なし
機能変更:
商品編集ページにおけるプレビュー表示の実装
出品ページにて登録された画像を表示し、編集削除出来るようにした。（一枚のみ）

# Why
出品した商品を編集する際に画像を確認する必要があるため
スクショ:
編集前
[![Image from Gyazo](https://i.gyazo.com/70dfc1ed74736ea11238b8298371aca4.png)](https://gyazo.com/70dfc1ed74736ea11238b8298371aca4)
変更動作
[![Image from Gyazo](https://i.gyazo.com/079589bc8b89717621dd3281178cdd39.gif)](https://gyazo.com/079589bc8b89717621dd3281178cdd39)
変更後
[![Image from Gyazo](https://i.gyazo.com/6c8bc7d34d23c4c0c9fc22e97195e863.png)](https://gyazo.com/6c8bc7d34d23c4c0c9fc22e97195e863)