### PR TITLE
[WIP]住所登録のテスト

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,7 @@
 class Address < ApplicationRecord
   belongs_to :user, optional: true
   validates :postal_code, :prefecture, :city, :address, presence: true
+  validates :postal_code, format: { with: /\A\d{3}[-]\d{4}$|^\d{3}[-]\d{2}$|^\d{3}\z/ }
 
   enum prefecture:{
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :address do
+    postal_code      {"111-1111"}
+    prefecture       {"北海道"}
+    city             {"札幌市"}
+    address          {"青葉区1-1-1"}
+    apartment        {"柳ビル101"}
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+describe Address do
+  describe '#create' do
+    it "全て入力されていればOK" do
+      address = build(:address)
+      expect(address).to be_valid
+    end
+    it "postal_codeが空ならNG" do
+      address = build(:address, postal_code: nil)
+      address.valid?
+      expect(address.errors[:postal_code]).to include("can't be blank")
+    end
+    it "postal_codeが意図しない形ならNG（全角）" do
+      address = build(:address, postal_code: "１１１ー１１１１")
+      address.valid?
+      expect(address.errors[:postal_code]).to include("is invalid")
+    end
+    it "postal_codeが意図しない形ならNG（ハイフンなし）" do
+      address = build(:address, postal_code: "1111111")
+      address.valid?
+      expect(address.errors[:postal_code]).to include("is invalid")
+    end
+    it "prefectureが空ならNG" do
+      address = build(:address, prefecture: nil)
+      address.valid?
+      expect(address.errors[:prefecture]).to include("can't be blank")
+    end
+    it "cityが空ならNG" do
+      address = build(:address, city: nil)
+      address.valid?
+      expect(address.errors[:city]).to include("can't be blank")
+    end
+    it "addressが空ならNG" do
+      address = build(:address, address: nil)
+      address.valid?
+      expect(address.errors[:address]).to include("can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
## WHAT
-Gem変更:なし
-DB変更：なし
-機能変更：
①テストコードの記入（住所登録のバリデーションテスト）
　spec/models/address_spec.rb　に追加しています

②addressモデル（app/models/address.rb）にバリデーションを追加
　・アパート以外は空欄不可
　・郵便番号はハイフン有りのinteger 3桁・5桁・7桁

-スクショ：
住所登録のバリデーションテストの結果
https://gyazo.com/c9bff3ec29b9f4ef355b849db11bcbee

## WHY
アプリの完成精度を高めるためにはテストが必要であるため