### PR TITLE
コメント機能ユーザー分岐の実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  
+    
     before_action :set_product
     def new
       @comment = Comment.new
@@ -19,7 +19,7 @@ class CommentsController < ApplicationController
     end
     private
     def comment_params
-      params.require(:comment).permit(:comment,:product_id)
+      params.require(:comment).permit(:comment,:product_id).merge(user_id: current_user.id)
     end
     def set_product
       @product = Product.find(params[:product_id])

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ApplicationRecord
   belongs_to :product
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_one :creditcard
   has_many :sns_credentials
   has_many :products
+  has_many :comments
   def self.from_omniauth(auth)
     sns = SnsCredential.where(provider: auth.provider, uid: auth.uid).first_or_create
     user = sns.user || User.where(email: auth.info.email).first_or_initialize(

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -94,9 +94,13 @@
                     = simple_format(comment.comment)
           .message-content
             %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-          = form_for [@product,@comment] do |c|
-            =c.text_area :comment,class:"text_area-default"
-            =c.submit 'コメントする',class:"text_area-default_btn"
+          - if current_user
+            = form_for [@product,@comment] do |c|
+              =c.text_area :comment,class:"text_area-default"
+              =c.submit 'コメントする',class:"text_area-default_btn"
+          - else
+            .not-comment
+              コメントはできません
       .product-social-media-box
         .text-center
           %ul.social-media-box

--- a/db/migrate/20200125120245_create_comments.rb
+++ b/db/migrate/20200125120245_create_comments.rb
@@ -3,6 +3,7 @@ class CreateComments < ActiveRecord::Migration[5.0]
     create_table :comments do |t|
       t.text     :comment
       t.references :product,foreign_key:true
+      t.references :user,foreign_key:true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,14 +13,14 @@
 ActiveRecord::Schema.define(version: 20200125120245) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "postal_code", null: false
-    t.integer  "prefecture",  null: false
-    t.string   "city",        null: false
-    t.string   "address",     null: false
+    t.string   "postal_code", limit: 7, null: false
+    t.integer  "prefecture",            null: false
+    t.string   "city",                  null: false
+    t.string   "address",               null: false
     t.string   "apartment"
-    t.integer  "user_id",     null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "user_id",               null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
     t.index ["user_id"], name: "index_addresses_on_user_id", using: :btree
   end
 
@@ -34,9 +34,11 @@ ActiveRecord::Schema.define(version: 20200125120245) do
   create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text     "comment",    limit: 65535
     t.integer  "product_id"
+    t.integer  "user_id"
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.index ["product_id"], name: "index_comments_on_product_id", using: :btree
+    t.index ["user_id"], name: "index_comments_on_user_id", using: :btree
   end
 
   create_table "creditcards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -64,14 +66,11 @@ ActiveRecord::Schema.define(version: 20200125120245) do
     t.integer  "price"
     t.text     "explain",       limit: 65535, null: false
     t.integer  "postage",                     null: false
-    t.string   "region"
     t.integer  "status"
     t.integer  "shipping_date"
     t.integer  "size"
     t.integer  "brand_id"
     t.integer  "category_id"
-    t.string   "product"
-    t.string   "image"
     t.integer  "prefecture"
     t.integer  "user_id"
     t.datetime "created_at",                  null: false
@@ -110,6 +109,7 @@ ActiveRecord::Schema.define(version: 20200125120245) do
 
   add_foreign_key "addresses", "users"
   add_foreign_key "comments", "products"
+  add_foreign_key "comments", "users"
   add_foreign_key "creditcards", "users"
   add_foreign_key "images", "products"
   add_foreign_key "products", "users"


### PR DESCRIPTION
# What 
DB変更有り:commentテーブルにuser_idカラム追加
機能変更：
ログインユーザーのみがコメント投稿できるように変更
associationの設定、コメントにuser_idを持たせるように変更
# Why
どのユーザーがコメントをしたか分岐するため。今後の実装をやりやすくするため