### PR TITLE
商品詳細ページにおける通貨表示の変更

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -57,7 +57,7 @@
               %td=@product.shipping_date         
         .product-details-page__price
           %span.product-price.bold
-            =@product.price
+            = number_to_currency(@product.price,unit:"¥",precision: 0)
           %span.product-tax          (税込)
           %span.product-shipping-fee 送料込み
         .product-buy__btn__box


### PR DESCRIPTION
# What
ビューの変更
商品詳細ページで出力される通貨表示を変更した。

# Why
通貨単位を日本円にし、3桁表示にした方が見やすいため
スクショ
https://gyazo.com/cb5e57898e0c7fc04e7465b7c633b4bd