### PR TITLE
コメント非同期通信追加

### DIFF
--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,6 +1,9 @@
 $(function () {
   function buildHTML(comment) {
     var html = `<div class="comments-block" data-comment-id="${comment}">
+    <div class="one-block">
+       ${comment.nickname}
+    </div>
         <div class="item-comment">
            ${comment.comment}
         </div>

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -10,7 +10,7 @@ class ProductsController < ApplicationController
 
   def show
     @comment =Comment.new
-    @comments =@product.comments
+    @comments =@product.comments.includes(:user).all
     
   end
 

--- a/app/views/comments/create.json.jbuilder
+++ b/app/views/comments/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.comment @comment.comment
-
+json.nickname @comment.user.nickname
 json.id @comment.id
 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -57,7 +57,7 @@
               %td=@product.shipping_date         
         .product-details-page__price
           %span.product-price.bold
-            = number_to_currency(@product.price,unit:"¥",precision: 0)
+            = number_to_currency(@product.price,format: "%u%n",unit:"¥",precision: 0)
           %span.product-tax          (税込)
           %span.product-shipping-fee 送料込み
         .product-buy__btn__box

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -90,7 +90,7 @@
             - if @product.comments
               - @product.comments.each do |comment|
                 .one-block
-                  =@product.user.nickname
+                  =comment.user.nickname
                   .item-comment
                     = simple_format(comment.comment)
           .message-content


### PR DESCRIPTION
# What 
コメントを投稿したユーザーをニックネームで表示されるように修正
コメント投稿者も非同期通信で表示されるように追記
通貨単位の表示ビューが崩れていたので修正

# Why 
出品した商品に対してユーザーがやりとりをスムーズに行えるようにするため。

スクショ
https://gyazo.com/846bbb424f998f3f60c2f068e608c311
