### PR TITLE
pay.jpを用いたクレジットカード登録

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,4 +81,5 @@ gem 'pry-rails'
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 gem "omniauth-rails_csrf_protection"
+gem 'payjp'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     excon (0.72.0)
     execjs (2.7.0)
@@ -139,6 +141,9 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     image_processing (1.10.3)
@@ -177,6 +182,7 @@ GEM
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
+    netrc (0.11.0)
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
@@ -203,6 +209,8 @@ GEM
       omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     owlcarousel-rails (2.2.3.5)
+    payjp (0.0.7)
+      rest-client (~> 2.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -248,6 +256,11 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
@@ -308,6 +321,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -351,6 +367,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   owlcarousel-rails
+  payjp
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,0 +1,38 @@
+$(function() {
+  Payjp.setPublicKey('pk_test_57c5bfaa1f1d1f2acd058a77');
+  $("#charge-form").on('click', function(e){
+    e.preventDefault();
+    // form.find("input[type=submit]").prop("disabled", true);
+    let card = {
+        number: $('#creditcard_card_number').val(),
+        cvc:$('#creditcard_card_pass').val(),
+        exp_month: $('#creditcard_card_month').val(),
+        exp_year: $('#creditcard_card_year').val()
+    };
+    console.log(card);
+
+    Payjp.createToken(card, function(status, response) {
+
+      console.log(status);
+
+      if (response.error) {
+        // form.find('.payment-errors').text(response.error.message);
+        $("#charge-form").prop('disabled', false);
+        alert("カード情報が正しくありません。");
+      }
+      else {
+        $(".number").removeAttr("name");
+        $(".cvc").removeAttr("name");
+        $(".exp_month").removeAttr("name");
+        $(".exp_year").removeAttr("name");
+
+        let token = response.id;
+        console.log(token);
+        $("#card_token").append(`<input type="hidden" name="payjpToken" value=${token}>`);
+        $("#form").get(0).submit();
+        console.log($("#charge-form"));
+        alert("登録が完了しました");
+      }
+    });
+  });
+});

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -2,19 +2,15 @@ $(function() {
   Payjp.setPublicKey('pk_test_57c5bfaa1f1d1f2acd058a77');
   $("#charge-form").on('click', function(e){
     e.preventDefault();
-    // form.find("input[type=submit]").prop("disabled", true);
     let card = {
         number: $('#creditcard_card_number').val(),
         cvc:$('#creditcard_card_pass').val(),
         exp_month: $('#creditcard_card_month').val(),
         exp_year: $('#creditcard_card_year').val()
     };
-    console.log(card);
 
     Payjp.createToken(card, function(status, response) {
-      console.log(status);
       if (response.error) {
-
         $("#charge-form").prop('disabled', false);
         alert("カード情報が正しくありません。");
       }
@@ -23,12 +19,9 @@ $(function() {
         $(".cvc").removeAttr("name");
         $(".exp_month").removeAttr("name");
         $(".exp_year").removeAttr("name");
-
         let token = response.id;
-        console.log(token);
         $("#card_token").append(`<input type="hidden" name="payjpToken" value=${token}>`);
         $("#form").get(0).submit();
-        console.log($("#charge-form"));
         alert("登録が完了しました");
       }
     });

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -12,11 +12,8 @@ $(function() {
     console.log(card);
 
     Payjp.createToken(card, function(status, response) {
-
       console.log(status);
-
       if (response.error) {
-        // form.find('.payment-errors').text(response.error.message);
         $("#charge-form").prop('disabled', false);
         alert("カード情報が正しくありません。");
       }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,4 @@
 @import "mypage-edit";
 @import "slick-theme"; 
 @import "slick";
+@import "card";

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -1,0 +1,42 @@
+.payment{
+  background: #fff;
+  &-header{
+    font-size: 24px;
+    padding: 8px 24px;
+    border-bottom: 1px solid #f5f5f5;
+    text-align: center;
+    line-height: 1.4;
+  }
+  &-title{
+    font-size: 16px;
+  }
+  &-content{
+    &__main{
+    padding: 64px;
+    border-top: 1px solid #f5f5f5;
+    }
+    &__creditcards{
+      max-width: 320px;
+      margin: 0 auto;
+      &__list{
+        padding: 24px 0;
+        border-bottom: 1px solid #eee;
+        position: relative;
+        max-width: 320px;
+        margin: 0 auto;
+        &__number{
+          margin: 8px 0 0;
+          font-size: 16px;
+        }
+      }
+  
+    }
+  }
+}
+
+#card_image{
+  width:49px;
+  height:15px;
+}
+
+

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,0 +1,42 @@
+class CardsController < ApplicationController
+  require "payjp"
+  before_action :set_creditcard
+
+  def show
+    Payjp.api_key = "sk_test_be263def71d21c8f58b223e3"
+    customer = Payjp::Customer.retrieve(@creditcard.customer_id)
+    @creditcard_information = customer.cards.retrieve(@creditcard.card_id)
+    @card_brand = @creditcard_information.brand 
+    case @card_brand
+    when "Visa"
+      @card_src = "visa.svg"
+    when "JCB"
+      @card_src = "jcb.svg"
+    when "MasterCard"
+      @card_src = "master-card.svg"
+    when "American Express"
+      @card_src = "american_express.svg"
+    when "Diners Club"
+      @card_src = "dinersclub.svg"
+    when "Discover"
+      @card_src = "discover.svg"
+    end
+  end
+
+  def destroy #PayjpとCardのデータベースを削除
+    Payjp.api_key = "秘密鍵"
+    customer = Payjp::Customer.retrieve(@card.customer_id)
+    customer.delete
+    if @card.destroy #削除に成功した時にポップアップを表示します。
+      redirect_to action: "index", notice: "削除しました"
+    else #削除に失敗した時にアラートを表示します。
+      redirect_to action: "index", alert: "削除できませんでした"
+    end
+  end
+
+  private
+
+  def set_creditcard
+    @creditcard = Creditcard.where(user_id: current_user.id).first if Creditcard.where(user_id: current_user.id).present?
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -44,11 +44,25 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create_creditcard
     @user = User.new(session["devise.regist_data"]["user"])
     @address = Address.new(session["address"])
+    Payjp.api_key = 'sk_test_be263def71d21c8f58b223e3'
+    if params['payjpToken'].blank?
+      redirect_to action: "new"
+    else
+      # 顧客情報をPAY.JPに登録。
+      customer = Payjp::Customer.create(
+        description: 'test', 
+        email: @user.email,
+        card: params['payjpToken'], 
+      )
+    end
     @creditcard = Creditcard.new(creditcard_params)
+    @creditcard[:customer_id]=customer.id
+    @creditcard[:card_id]=customer.default_card
     unless @creditcard.valid?
       flash.now[:alert] = @creditcard.errors.full_messages
       render :new_credit_card and return
     end
+    binding.pry
     @user.build_address(@address.attributes)
     @user.build_creditcard(@creditcard.attributes)
     if @user.save

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,7 +1,7 @@
 class Address < ApplicationRecord
   belongs_to :user, optional: true
   validates :postal_code, :prefecture, :city, :address, presence: true
-  validates :postal_code, format: { with: /\A^\d{3}[-]\d{4}$|^\d{3}[-]\d{2}$|^\d{3}$\z/ }
+  validates :postal_code, format: { with: /\A\d{3}[-]\d{4}$|^\d{3}[-]\d{2}$|^\d{3}\z/ }
 
   enum prefecture:{
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,0 +1,123 @@
+=render "home/header_login"
+.mypage_a  
+  %main.mypage-contents.clearfix
+    .main-content
+      .payment
+        .payment-content
+          .payment-content__title
+            %h1.payment-header 支払い方法
+          .payment-content__main
+            .payment-content__creditcards
+              %h2.payment-title クレジットカード一覧
+            .payment-content__creditcards__list
+              %figure
+                = image_tag "#{@card_src}",alt: @card_brand, id: "card_image"
+              .payment-content__creditcards__list__number
+                = "**** **** **** " + @creditcard_information.last4
+              .payment-content__creditcards__list__number
+                - exp_month = @creditcard_information.exp_month.to_s
+                - exp_year = @creditcard_information.exp_year.to_s.slice(2,3)
+                = exp_month + " / " + exp_year
+    .side-content
+      %nav.mypage-nav
+        %ul.mypage-nav-list
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              マイページ
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              お知らせ
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              やることリスト
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              いいね！一覧
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              出品する
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              出品した商品 - 出品中
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              出品した商品 - 取引中
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              出品した商品 - 売却済み
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              購入した商品 - 取引中
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              購入した商品 - 過去の取引
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              ニュース一覧
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              評価一覧
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              ガイド
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              お問い合わせ
+              %i.icon-arrow-right
+        %h3.mypage-nav-head-merpay メルペイ
+        %ul.mypage-nav-list-merpay
+          %li
+            =link_to "#", class: "mypage-nav-list-merpay-item" do
+              売上・振込申請
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-merpay-item" do
+              ポイント
+              %i.icon-arrow-right
+        %h3.mypage-nav-head-setting 設定
+        %ul.mypage-nav-list-setting
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              プロフィール
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              発送元・お届け先住所変更
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              支払い方法
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              メール/パスワード
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              本人情報
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              電話番号の確認
+              %i.icon-arrow-right
+          %li
+            =link_to destroy_user_session_path, method: :delete, class: "mypage-nav-list-setting-item" do
+              ログアウト
+              %i.icon-arrow-right
+=render "home/footer"
+
+
+

--- a/app/views/devise/registrations/new_credit_card.html.haml
+++ b/app/views/devise/registrations/new_credit_card.html.haml
@@ -71,4 +71,5 @@
       .form-group
         = f.submit "登録する", class: "btn-default btn-red", url: "creditcards_path",id:"charge-form",method: :post
       #card_token
+      %input.payjp-token{ type: "hidden", name: "creditcard[payjpToken]", value: "" }
   = render "/registration/registration_footer"

--- a/app/views/devise/registrations/new_credit_card.html.haml
+++ b/app/views/devise/registrations/new_credit_card.html.haml
@@ -25,12 +25,12 @@
 
 .single-main__container__form
   .single-main__container__form__frame
-    = form_for(@creditcard, url: creditcards_path,method: :post) do |f|
+    = form_for(@creditcard, url: creditcards_path,method: :post,html: {id: "form" }) do |f|
       = render "devise/shared/error_messages", resource: @creditcard
       .form-group
         = f.label :カード番号
         %span.form-group__require 必須
-        = f.text_field :card_number, {placeholder: "半角数字のみ", class: "form-group__input"}
+        = f.text_field :card_number, {placeholder: "半角数字のみ", class: "form-group__input",maxlength:"16"}
       .form-group
         = f.label :カード会社
         %span.form-group__require 必須
@@ -54,9 +54,10 @@
         = f.label :有効期限
         %span.form-group__require 必須
         %br
-        = f.select :card_year, options_for_select(["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]), {}, {class: "form-group__input--half"}
+        = f.select :card_month, options_for_select(["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]), {}, {class: "form-group__input--half"}
         = f.label :月, class: "form-group__card--year-and-month"
-        = f.select :card_month, options_for_select(["20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30"]), {}, {class: "form-group__input--half"}
+        -# = f.select :card_year, options_for_select(["20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30"]), {}, {class: "form-group__input--half"}
+        = f.select :card_year, options_for_select((2020..2030)), {}, {class: "form-group__input--half"}
         = f.label :年, class: "form-group__card--year-and-month"
       .form-group
         = f.label :セキュリティコード, class: "label"
@@ -68,7 +69,6 @@
         %p.form-group__text--right--blue
           カード裏面の番号とは？
       .form-group
-        = f.submit "登録する", class: "btn-default btn-red", url: "creditcards_path", method: :post
+        = f.submit "登録する", class: "btn-default btn-red", url: "creditcards_path",id:"charge-form",method: :post
+      #card_token
   = render "/registration/registration_footer"
-
-  f.submit "Sign up"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,6 +3,8 @@
   %head
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title FreemarketSample60ce
+    %script{src: "https://js.pay.jp/", type: "text/javascript"}
+    %script{type: "text/javascript"}Payjp.setPublicKey('pk_test_57c5bfaa1f1d1f2acd058a77');
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     %link{href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css", rel: "stylesheet", type: "text/css"}/

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -188,7 +188,7 @@
               発送元・お届け先住所変更
               %i.icon-arrow-right
           %li
-            =link_to "#", class: "mypage-nav-list-setting-item" do
+            =link_to card_path, class: "mypage-nav-list-setting-item" do
               支払い方法
               %i.icon-arrow-right
           %li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,5 @@ Rails.application.routes.draw do
     end
   end
   resources :registration, only: [:index]
+  resources :cards, only: [:show]
 end

--- a/db/migrate/20200119082708_create_creditcards.rb
+++ b/db/migrate/20200119082708_create_creditcards.rb
@@ -7,6 +7,8 @@ class CreateCreditcards < ActiveRecord::Migration[5.0]
       t.integer    :card_month, null: false
       t.integer    :card_pass, null: false
       t.references :user, null: false, foreign_key: true
+      t.string :customer_id, null: false
+      t.string :card_id, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,14 +13,14 @@
 ActiveRecord::Schema.define(version: 20200125120245) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "postal_code", null: false
-    t.integer  "prefecture",  null: false
-    t.string   "city",        null: false
-    t.string   "address",     null: false
+    t.string   "postal_code", limit: 7, null: false
+    t.integer  "prefecture",            null: false
+    t.string   "city",                  null: false
+    t.string   "address",               null: false
     t.string   "apartment"
-    t.integer  "user_id",     null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "user_id",               null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
     t.index ["user_id"], name: "index_addresses_on_user_id", using: :btree
   end
 
@@ -34,9 +34,11 @@ ActiveRecord::Schema.define(version: 20200125120245) do
   create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text     "comment",    limit: 65535
     t.integer  "product_id"
+    t.integer  "user_id"
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.index ["product_id"], name: "index_comments_on_product_id", using: :btree
+    t.index ["user_id"], name: "index_comments_on_user_id", using: :btree
   end
 
   create_table "creditcards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -46,6 +48,8 @@ ActiveRecord::Schema.define(version: 20200125120245) do
     t.integer  "card_month",   null: false
     t.integer  "card_pass",    null: false
     t.integer  "user_id",      null: false
+    t.string   "customer_id",  null: false
+    t.string   "card_id",      null: false
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
     t.index ["user_id"], name: "index_creditcards_on_user_id", using: :btree
@@ -64,19 +68,18 @@ ActiveRecord::Schema.define(version: 20200125120245) do
     t.integer  "price"
     t.text     "explain",       limit: 65535, null: false
     t.integer  "postage",                     null: false
-    t.string   "region"
     t.integer  "status"
     t.integer  "shipping_date"
     t.integer  "size"
     t.integer  "brand_id"
     t.integer  "category_id"
-    t.string   "product"
-    t.string   "image"
     t.integer  "prefecture"
+    t.integer  "user_id"
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
     t.index ["name"], name: "index_products_on_name", using: :btree
     t.index ["price"], name: "index_products_on_price", using: :btree
+    t.index ["user_id"], name: "index_products_on_user_id", using: :btree
   end
 
   create_table "sns_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -108,7 +111,9 @@ ActiveRecord::Schema.define(version: 20200125120245) do
 
   add_foreign_key "addresses", "users"
   add_foreign_key "comments", "products"
+  add_foreign_key "comments", "users"
   add_foreign_key "creditcards", "users"
   add_foreign_key "images", "products"
+  add_foreign_key "products", "users"
   add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
# What
 -Gem変更:pay.jp追加
 -DB変更：creditcardテーブル＊customer_idとcard_idのカラム追加
 -機能変更：クレジットカードの登録をpay.jpのAPIを活用したものに変更
 -スクショ：
    -pay.jp顧客情報
      https://gyazo.com/230e34dc2b8efb2a6fae7001f7a3020b
　-Squel pro DB情報
　  https://gyazo.com/c8f078b09fcf580115cbfeb824f2aed9
    -マイページからカード情報の確認
　 https://gyazo.com/1788e34081a29fe5864208d77e13ad89
 -その他：
  新規登録時にクレジットカード情報までセッションで保存した弊害発生。
　=>弊害：クレジットカードの削除/追加/編集ができない。
　=>新規登録時には住所までをセッションとし、クレジットカードは独立して登録させるべきであった。取り急ぎ、削除/追加/編集機能はなしとするが、時間があれば、上記のように新規登録の記述変更を検討する。

# Why
クレジットカード情報をpay.jpにリンクさせることで、カードを用いた購入機能などを実装するため。