### PR TITLE
商品出品サーバサイド#5

### DIFF
--- a/app/assets/stylesheets/_new.scss
+++ b/app/assets/stylesheets/_new.scss
@@ -388,7 +388,7 @@
             transition: all ease-out .3s;
             text-align: center;
           }
-          a.btn--gray {
+          .btn--gray {
             display: block;
             line-height: 48px;
             font-size: 14px;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -58,7 +58,7 @@ class ProductsController < ApplicationController
       @product.save
       redirect_to root_path
     else
-      render :new
+      redirect_to root_path
     end
   end
 

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -161,7 +161,7 @@
             .actions
               =f.submit "出品する",class:"btn--red"
           %a.btn--gray 
-            =link_to "もどる",products_path,class:"btn--gry"
+            =link_to "もどる",products_path,class:"btn--gray"
   .exhibit-page__footer
     .exhibit-page__footer__content
       .exhibit-page__footer__content__main

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -160,7 +160,8 @@
               に同意したことになります。
             .actions
               =f.submit "出品する",class:"btn--red"
-          %a.btn--gray もどる
+          %a.btn--gray 
+            =link_to "もどる",products_path,class:"btn--gry"
   .exhibit-page__footer
     .exhibit-page__footer__content
       .exhibit-page__footer__content__main

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -160,7 +160,6 @@
               に同意したことになります。
             .actions
               =f.submit "出品する",class:"btn--red"
-          %a.btn--gray 
             =link_to "もどる",products_path,class:"btn--gray"
   .exhibit-page__footer
     .exhibit-page__footer__content


### PR DESCRIPTION
# What
画像投稿が無い場合はトップページに遷移するように変更
戻るボタンを押すとトップページに遷移するように実装

# Why
商品出品の際、画像投稿が無い場合の遷移先が決まっていなかったため。
出品キャンセルの場合にトップページに戻れるようにする必要があるため。

スクショ
画像無し投稿
[![Image from Gyazo](https://i.gyazo.com/528fc976a9b5b83a52e3bb3e7b7f18d7.gif)](https://gyazo.com/528fc976a9b5b83a52e3bb3e7b7f18d7)

戻るの挙動
[![Image from Gyazo](https://i.gyazo.com/165621f5aefa9764754d844c367a4ae7.gif)](https://gyazo.com/165621f5aefa9764754d844c367a4ae7)

