### PR TITLE
取り置き機能実装

### DIFF
--- a/app/assets/stylesheets/_products-show.scss
+++ b/app/assets/stylesheets/_products-show.scss
@@ -157,6 +157,10 @@
     background:$Red;
     @include product-buy;
   }
+  .product-details-resorve__btn {
+    background:$Blue;
+    @include product-buy;
+  }
   .product-purchase__btn {
     background:$Red;
     cursor: hand;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,4 @@
 @import "mypage_main";
 @import "category";
 @import "buy";
+@import "reserve";

--- a/app/assets/stylesheets/buy.scss
+++ b/app/assets/stylesheets/buy.scss
@@ -74,6 +74,9 @@
   font-size: 14px;
 }
 
+
+
+
 .buy-user-info{
   padding: 32px 0;
   text-align: left;

--- a/app/assets/stylesheets/buy.scss
+++ b/app/assets/stylesheets/buy.scss
@@ -74,9 +74,6 @@
   font-size: 14px;
 }
 
-
-
-
 .buy-user-info{
   padding: 32px 0;
   text-align: left;

--- a/app/assets/stylesheets/products.index.scss
+++ b/app/assets/stylesheets/products.index.scss
@@ -259,9 +259,34 @@
     left: 0;
     z-index: 2;
     color: #fff;
-    -webkit-transform: rotate(-45deg);
     transform: rotate(-45deg);
     letter-spacing: 2px;
     font-weight: 600;
   }
 }
+
+
+.items-box_photo__reserved{
+  width: 0;
+  height: 0;
+  border-width: 120px 120px 0 0;
+  border-color: $Blue transparent transparent transparent;
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  border-style: solid;
+  &__inner{
+    top: -80px;
+    font-size: 20px;
+    position: absolute;
+    left: -5px;
+    z-index: 2;
+    color: #fff;
+    transform: rotate(-45deg);
+    letter-spacing: 2px;
+    font-weight: 600;
+  }
+}
+

--- a/app/assets/stylesheets/reserve.scss
+++ b/app/assets/stylesheets/reserve.scss
@@ -1,0 +1,13 @@
+.reserve{
+  width: 100%;
+  background: $Blue;
+  cursor: hand;
+  height: 48px;
+  line-height: 48px;
+  display: block;
+  margin: 16px 0 0;
+  color: #ffffff;
+  text-align: center;
+  font-weight: 600;
+  font-size: 14px;
+}

--- a/app/assets/stylesheets/reserve.scss
+++ b/app/assets/stylesheets/reserve.scss
@@ -11,3 +11,39 @@
   font-weight: 600;
   font-size: 14px;
 }
+
+.reserved{
+  background: #fff;
+  &-header{
+    font-size: 24px;
+    padding: 8px 24px;
+    border-bottom: 1px solid #f5f5f5;
+    text-align: center;
+    line-height: 1.4;
+  }
+  &-title{
+    font-size: 16px;
+  }
+  &-content{
+    &__main{
+    padding: 64px;
+    border-top: 1px solid #f5f5f5;
+    }
+    &__creditcards{
+      max-width: 320px;
+      margin: 0 auto;
+      &__list{
+        padding: 24px 0;
+        border-bottom: 1px solid #eee;
+        position: relative;
+        max-width: 320px;
+        margin: 0 auto;
+        &__number{
+          margin: 8px 0 0;
+          font-size: 16px;
+        }
+      }
+  
+    }
+  }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -74,7 +74,12 @@ class ProductsController < ApplicationController
   def reserved
     @product = Product.find(params[:id])
     @product.update(product_params)
+  end
 
+  def reserve_cancel
+    @product = Product.find(params[:id])
+    @product.update(reservation_email:"")
+    redirect_to product_path
   end
 
 
@@ -103,6 +108,9 @@ class ProductsController < ApplicationController
       customer: Payjp::Customer.retrieve(@creditcard.customer_id),
       currency: 'jpy'
     )
+    if @product.reservation_email.present?
+      @product.update(reservation_email:"")
+    end
     @product_buyer= Product.find(params[:id])
     @product_buyer.update( buyer_id: current_user.id)
     redirect_to purchased_product_path

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -69,7 +69,12 @@ class ProductsController < ApplicationController
 
   def reserve
     @product = Product.find(params[:id])
-    
+  end
+
+  def reserved
+    @product = Product.find(params[:id])
+    @product.update(product_params)
+
   end
 
 
@@ -106,7 +111,7 @@ class ProductsController < ApplicationController
 
   private
     def product_params
-      params.require(:product).permit(:name,:category_id,:price,:explain,:size,:brand_id,:status,:postage,:shipping_date,:prefecture,images_attributes: [:product_image,:_destroy,:id]).merge(user_id: current_user.id)
+      params.require(:product).permit(:name,:category_id,:price,:explain,:size,:brand_id,:status,:postage,:shipping_date,:prefecture,:reservation_email,images_attributes: [:product_image,:_destroy,:id]).merge(user_id: current_user.id)
     end
 
     def set_product

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -67,6 +67,12 @@ class ProductsController < ApplicationController
     @comments =@product.comments
   end
 
+  def reserve
+    @product = Product.find(params[:id])
+    
+  end
+
+
   def update
     if @product.update(update_params)
       redirect_to product_path

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -71,11 +71,18 @@ class ProductsController < ApplicationController
 
   def reserved
     @product.update(product_params)
+    if @product.reservation_email.present?
+    else
+      render :reserve
+    end
   end
 
   def reserve_cancel
-    @product.update(reservation_email:"")
+    if @product.update(reservation_email:"")
     redirect_to product_path
+    else
+    redirect_to product_path
+    end
   end
 
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   require 'payjp'
-  before_action :set_product, only: [:show,:comment,:edit,:update]
+  before_action :set_product, only: [:show,:comment,:edit,:update,:buy,:reserved,:reserve,:reserve_cancel,:destroy,:purchase]
   before_action :set_creditcard, only: [:buy, :purchase]
   before_action :set_product_purchase, only: [:buy, :purchase]
   
@@ -22,7 +22,6 @@ class ProductsController < ApplicationController
 
   def buy
     @address = Address.where(user_id: current_user.id).first
-    @product = Product.find(params[:id])
     Payjp.api_key = Rails.application.secrets.payjp_access_key
     customer = Payjp::Customer.retrieve(@creditcard.customer_id)
     @creditcard_information = customer.cards.retrieve(@creditcard.card_id)
@@ -68,16 +67,13 @@ class ProductsController < ApplicationController
   end
 
   def reserve
-    @product = Product.find(params[:id])
   end
 
   def reserved
-    @product = Product.find(params[:id])
     @product.update(product_params)
   end
 
   def reserve_cancel
-    @product = Product.find(params[:id])
     @product.update(reservation_email:"")
     redirect_to product_path
   end
@@ -92,7 +88,6 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    product = Product.find(params[:id])
     if product.destroy
       redirect_to root_path, notice: '削除しました'
     else
@@ -101,7 +96,6 @@ class ProductsController < ApplicationController
   end
 
   def purchase
-    @product = Product.find(params[:id])
     Payjp.api_key = Rails.application.secrets.payjp_access_key
     charge = Payjp::Charge.create(
       amount: @product.price,

--- a/app/views/products/_product.html.haml
+++ b/app/views/products/_product.html.haml
@@ -14,3 +14,6 @@
           -if product.buyer_id.present? 
             .items-box_photo__sold
               .items-box_photo__sold__inner SOLD
+          -if product.reservation_email.present? 
+            .items-box_photo__reserved
+              .items-box_photo__reserved__inner Reserved

--- a/app/views/products/reserve.html.haml
+++ b/app/views/products/reserve.html.haml
@@ -22,6 +22,9 @@
             %br/
             = f.email_field :reservation_email, {autofocus: true, autocomplete: "email", placeholder: "PC・携帯どちらでも可",class:'form-group__input'}
             = f.submit '取り置きする', class: "reserve"
+        - if @product.reservation_email.present?
+          =link_to reserve_cancel_product_path,method: :patch, class:"btn-default btn-red" do
+            取り置きをやめる
 .exhibit-page__footer
   .exhibit-page__footer__content
     .exhibit-page__footer__content__main

--- a/app/views/products/reserve.html.haml
+++ b/app/views/products/reserve.html.haml
@@ -1,33 +1,27 @@
 =render 'single-container'
 
 %main.buy-main 
-  = form_tag(action: :reserved, method: :post) do
-    .buy-item-container
-      %h2.buy-item-head 取り置き内容の確認
-      %section.buy-content.buy-item
-        .buy-content-inner
-          .buy-item-box
-            .buy-item-image
-              =image_tag(@product.images[0].product_image.url,class:"buy-image")
-            .buy-item-detail
-              %p.buy-item-name
-                =@product.name
-                %p.buy-item-price.bold
-                  = number_to_currency(@product.price,format: "%u%n",unit:"¥",precision: 0)
-                  %span.item-shipping-fee.f14.bold
-                    (税込)送料込み
+  .buy-item-container
+    %h2.buy-item-head 取り置き内容の確認
+    %section.buy-content.buy-item
+      .buy-content-inner
+        .buy-item-box
+          .buy-item-image
+            =image_tag(@product.images[0].product_image.url,class:"buy-image")
+          .buy-item-detail
+            %p.buy-item-name
+              =@product.name
+              %p.buy-item-price.bold
+                = number_to_currency(@product.price,format: "%u%n",unit:"¥",precision: 0)
+                %span.item-shipping-fee.f14.bold
+                  (税込)送料込み
+        =form_for(@product, url: reserved_product_path,method: :patch) do |f|
           .form-group
-            =label_tag :お取り置きをする方のアドレス
+            =f.label :お取り置きをする方のアドレス
             %span.form-group__require 必須
             %br/
-            =email_field_tag :email
-          .form-group
-            =label_tag :お取り置き期間
-            %span.form-group__require 必須
-            %br/
-            =number_field_tag :time
-            時間
-          = submit_tag("取り置きする", class:"reserve")
+            = f.email_field :reservation_email, {autofocus: true, autocomplete: "email", placeholder: "PC・携帯どちらでも可",class:'form-group__input'}
+            = f.submit '取り置きする', class: "reserve"
 .exhibit-page__footer
   .exhibit-page__footer__content
     .exhibit-page__footer__content__main

--- a/app/views/products/reserve.html.haml
+++ b/app/views/products/reserve.html.haml
@@ -1,0 +1,42 @@
+=render 'single-container'
+
+%main.buy-main 
+  = form_tag(action: :reserved, method: :post) do
+    .buy-item-container
+      %h2.buy-item-head 取り置き内容の確認
+      %section.buy-content.buy-item
+        .buy-content-inner
+          .buy-item-box
+            .buy-item-image
+              =image_tag(@product.images[0].product_image.url,class:"buy-image")
+            .buy-item-detail
+              %p.buy-item-name
+                =@product.name
+                %p.buy-item-price.bold
+                  = number_to_currency(@product.price,format: "%u%n",unit:"¥",precision: 0)
+                  %span.item-shipping-fee.f14.bold
+                    (税込)送料込み
+          .form-group
+            =label_tag :お取り置きをする方のアドレス
+            %span.form-group__require 必須
+            %br/
+            =email_field_tag :email
+          .form-group
+            =label_tag :お取り置き期間
+            %span.form-group__require 必須
+            %br/
+            =number_field_tag :time
+            時間
+          = submit_tag("取り置きする", class:"reserve")
+.exhibit-page__footer
+  .exhibit-page__footer__content
+    .exhibit-page__footer__content__main
+      %ul.exhibit-page__footer__lists
+        %li.exhibit-page__footer__list
+          プライバシーポリシー
+        %li.exhibit-page__footer__list
+          メルカリ利用規約
+        %li.exhibit-page__footer__list
+          特定商取引に関する表記
+        %p.exhibit-page__footer__copyright
+          © 2019 Mercari

--- a/app/views/products/reserved.html.haml
+++ b/app/views/products/reserved.html.haml
@@ -1,0 +1,115 @@
+
+-if user_signed_in?
+  =render "home/header_login"
+-else
+  =render "home/header_unlogin"
+.mypage_a  
+  %main.mypage-contents.clearfix
+    .main-content
+      .reserved
+        .reserved-content
+          .reserved-content__title
+            %h1.reserved-header 取り置きが完了しました
+          .logout-content
+          =link_to root_path, class:"btn-default btn-red" do
+            トップページへ戻る
+    .side-content
+      %nav.mypage-nav
+        %ul.mypage-nav-list
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              マイページ
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              お知らせ
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              やることリスト
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              いいね！一覧
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              出品する
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              出品した商品 - 出品中
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              出品した商品 - 取引中
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              出品した商品 - 売却済み
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              購入した商品 - 取引中
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              購入した商品 - 過去の取引
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              ニュース一覧
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              評価一覧
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              ガイド
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-item" do
+              お問い合わせ
+              %i.icon-arrow-right
+        %h3.mypage-nav-head-merpay メルペイ
+        %ul.mypage-nav-list-merpay
+          %li
+            =link_to "#", class: "mypage-nav-list-merpay-item" do
+              売上・振込申請
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-merpay-item" do
+              ポイント
+              %i.icon-arrow-right
+        %h3.mypage-nav-head-setting 設定
+        %ul.mypage-nav-list-setting
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              プロフィール
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              発送元・お届け先住所変更
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              支払い方法
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              メール/パスワード
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              本人情報
+              %i.icon-arrow-right
+          %li
+            =link_to "#", class: "mypage-nav-list-setting-item" do
+              電話番号の確認
+              %i.icon-arrow-right
+          %li
+            =link_to destroy_user_session_path, method: :delete, class: "mypage-nav-list-setting-item" do
+              ログアウト
+              %i.icon-arrow-right
+=render "home/footer"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -67,6 +67,7 @@
         - if user_signed_in? && current_user.id ==@product.user_id
           = link_to "削除する", product_path(@product.id), method: :delete,class:"product-details-delete__btn"
           = link_to "編集する", edit_product_path(@product.id),class:"product-details-edit__btn"
+          = link_to "取り置きする", reserve_product_path(@product.id),class:"product-details-resorve__btn"
         - elsif @product.buyer_id.present? 
           = link_to "売り切れました",buy_product_path,class:"disabled-button bold"
         - else

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -12,9 +12,12 @@
       .product-details__page__main__content.clearfix
         .product-details__page__main__content__image
           =image_tag(@product.images[0].product_image.url)
-            -if @product.buyer_id.present? 
+          -if @product.buyer_id.present? 
             .items-box_photo__sold
               .items-box_photo__sold__inner SOLD
+          -if @product.reservation_email.present? 
+            .items-box_photo__reserved
+              .items-box_photo__reserved__inner Reserved
           .owl-dots
             .owl-dot
               .owl-dot-inner 
@@ -64,14 +67,18 @@
           %span.product-tax          (税込)
           %span.product-shipping-fee 送料込み
         .product-buy__btn__box       
-        - if user_signed_in? && current_user.id ==@product.user_id
-          = link_to "削除する", product_path(@product.id), method: :delete,class:"product-details-delete__btn"
-          = link_to "編集する", edit_product_path(@product.id),class:"product-details-edit__btn"
-          = link_to "取り置きする", reserve_product_path(@product.id),class:"product-details-resorve__btn"
-        - elsif @product.buyer_id.present? 
-          = link_to "売り切れました",buy_product_path,class:"disabled-button bold"
-        - else
-          = link_to "購入画面に進む",buy_product_path,class:"product-purchase__btn"
+          - if user_signed_in? && current_user.id ==@product.user_id
+            = link_to "削除する", product_path(@product.id), method: :delete,class:"product-details-delete__btn"
+            = link_to "編集する", edit_product_path(@product.id),class:"product-details-edit__btn"
+            = link_to "取り置きする", reserve_product_path(@product.id),class:"product-details-resorve__btn"
+          - elsif @product.buyer_id.present? 
+            = link_to "売り切れました",buy_product_path,class:"disabled-button bold"
+          - elsif @product.reservation_email.present? && @product.reservation_email == current_user.email
+            = link_to "取り置き商品を購入する",buy_product_path,class:"product-purchase__btn"
+          - elsif @product.reservation_email.present? && @product.reservation_email != current_user.email
+            = link_to "取り置き商品のため購入できません",buy_product_path,class:"disabled-button bold"
+          - else
+            = link_to "購入画面に進む",buy_product_path,class:"product-purchase__btn"
         .product-details-page-bottom.clearfix
           .product-button-left
             = link_to '#',class:'product-button-like' do

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -70,7 +70,7 @@
           - if user_signed_in? && current_user.id ==@product.user_id
             = link_to "削除する", product_path(@product.id), method: :delete,class:"product-details-delete__btn"
             = link_to "編集する", edit_product_path(@product.id),class:"product-details-edit__btn"
-            = link_to "取り置きする", reserve_product_path(@product.id),class:"product-details-resorve__btn"
+            = link_to "取り置きする/編集する", reserve_product_path(@product.id),class:"product-details-resorve__btn"
           - elsif @product.buyer_id.present? 
             = link_to "売り切れました",buy_product_path,class:"disabled-button bold"
           - elsif @product.reservation_email.present? && @product.reservation_email == current_user.email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
       post 'purchase'
       get 'purchased'
       get 'buy'
+      get 'reserve'
+      post 'reserving'
+      get 'reserved'
     end
     resources :comments,only:[:create,:destroy]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,14 +20,14 @@ Rails.application.routes.draw do
   namespace :products do
     resources :searches, only: :index
   end
+  
   resources :products do
     member do
       post 'purchase'
       get 'purchased'
       get 'buy'
       get 'reserve'
-      post 'reserving'
-      get 'reserved'
+      patch 'reserved'
     end
     resources :comments,only:[:create,:destroy]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
       get 'buy'
       get 'reserve'
       patch 'reserved'
+      patch 'reserve_cancel'
     end
     resources :comments,only:[:create,:destroy]
   end

--- a/db/migrate/20200114134313_create_products.rb
+++ b/db/migrate/20200114134313_create_products.rb
@@ -13,6 +13,7 @@ class CreateProducts < ActiveRecord::Migration[5.0]
       t.integer :prefecture
       t.integer :buyer_id
       t.references :user,index: true, foreign_key: true
+      t.string :reservation_email
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,10 +64,10 @@ ActiveRecord::Schema.define(version: 20200125120245) do
   end
 
   create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",          limit: 191,   null: false
+    t.string   "name",              limit: 191,   null: false
     t.integer  "price"
-    t.text     "explain",       limit: 65535, null: false
-    t.integer  "postage",                     null: false
+    t.text     "explain",           limit: 65535, null: false
+    t.integer  "postage",                         null: false
     t.integer  "status"
     t.integer  "shipping_date"
     t.integer  "size"
@@ -76,8 +76,9 @@ ActiveRecord::Schema.define(version: 20200125120245) do
     t.integer  "prefecture"
     t.integer  "buyer_id"
     t.integer  "user_id"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.string   "reservation_email"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.index ["name"], name: "index_products_on_name", using: :btree
     t.index ["price"], name: "index_products_on_price", using: :btree
     t.index ["user_id"], name: "index_products_on_user_id", using: :btree


### PR DESCRIPTION
# What
- Gem変更:なし
- DB変更：あり　productテーブルに"reservation_email"カラム追加
- 機能変更：取り置き機能追加
　　　　　　-emailをキーとして、特定の顧客以外は購入できないようにしました。
　　　　　　-また、取り置きをキャンセルする機能も実装しました。
- スクショ：
取り置きをする
https://gyazo.com/93e91b84b897beeb3c80adea9bd6a3e7
取り置き商品を購入する（特定顧客のみ）
https://gyazo.com/873e1383a7c395393b0f89e6c45a274f
他の顧客は買えないようにする
https://gyazo.com/7d96a91d4258ab8a0a7d92a415e2169f
取り置きキャンセル
https://gyazo.com/e0464a897d30f66eba1551be0c0421e0

- その他：購入後のビューの崩れは別ブランチにて対応します。

# Why
より良いサービスを提供するための追加機能を実装するため。